### PR TITLE
Update README.md with clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ mkdir ../data
 ./test_in_place.sh -question-source="../example/example_questions.json"
 ```
 
-Note the server requires the extra flag "question-list," which instructs the
+Note the server requires the extra flag "question-source," which instructs the
 server where to look for questions. In this case, the example included in this
 repository.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ included script:
 cd server
 go get
 go build
-./test_in_place.sh --question-list="../example/example_questions.json"
+mkdir ../data
+./test_in_place.sh -question-source="../example/example_questions.json"
 ```
 
 Note the server requires the extra flag "question-list," which instructs the

--- a/README.md
+++ b/README.md
@@ -23,8 +23,18 @@ On Debian derivatives, you can install the required dependencies with:
 apt install golang-go npm
 ```
 
+### Compatibility Information
+
 This is built and tested with Go version 1.18, and requires at least 1.16 to 
 compile and run.
+
+It is recommended that you use an older version of node when building this
+project, such as version 14.10.0. If using nvm, run:
+
+```
+nvm install 14.10.0
+nvm use 14.10.0
+```
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ compile and run.
 
 First clone the project and navigate to the directory you checked it out into.
 
+**NOTE: The project must be cloned using the --recurse-submodules flag!**
+
 ```sh
-git clone https://github.com/baconstrip/kee-ken
+git clone --recurse-submodules https://github.com/baconstrip/kee-ken
 cd ./kee-ken
 ```
 


### PR DESCRIPTION
This PR is to address Issue #6, because the README currently doesn't note that the project has to be cloned with the `--recurse-submodules` flag.

This is a super tiny two-line change to the README to add this flag and note its requirement.

Thanks!